### PR TITLE
fix: skip terraform validate for composite modules in CI workflows

### DIFF
--- a/.github/workflows/pr-validate-modules.yml
+++ b/.github/workflows/pr-validate-modules.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - develop
+      - main
     paths:
       - 'modules/**'
 
@@ -149,8 +150,16 @@ jobs:
           MODULE_PATH: ${{ matrix.module_path }}
         run: |
           echo "Validating Terraform configuration..."
-          lace terraform validate --path "$MODULE_PATH"
-          echo "Terraform configuration is valid"
+
+          # Composite modules reference git sources that may not be tagged yet.
+          # Their structure is validated by lace module parse instead.
+          KIND=$(grep "^\s*kind:" "$MODULE_PATH/module.yaml" | head -1 | awk '{print $2}')
+          if [ "$KIND" = "composite" ]; then
+            echo "Composite module — skipping terraform validate (lace module parse handles validation)"
+          else
+            lace terraform validate --path "$MODULE_PATH"
+            echo "Terraform configuration is valid"
+          fi
 
       - name: Terraform Security Scan (Informational)
         env:

--- a/.github/workflows/terraform-registry-auto-register.yml
+++ b/.github/workflows/terraform-registry-auto-register.yml
@@ -175,10 +175,15 @@ jobs:
         run: |
           echo "🔍 Validating Terraform configuration..."
 
-          # Validate Terraform syntax and configuration
-          lace terraform validate --path "$MODULE_PATH"
-
-          echo "✅ Terraform configuration is valid"
+          # Composite modules reference git sources that may not be tagged yet.
+          # Their structure is validated by lace module parse instead.
+          KIND=$(grep "^\s*kind:" "$MODULE_PATH/module.yaml" | head -1 | awk '{print $2}')
+          if [ "$KIND" = "composite" ]; then
+            echo "ℹ️  Composite module — skipping terraform validate (lace module parse handles validation)"
+          else
+            lace terraform validate --path "$MODULE_PATH"
+            echo "✅ Terraform configuration is valid"
+          fi
 
       - name: Terraform Security Scan (Optional)
         env:

--- a/.github/workflows/terraform-registry-manual-register.yml
+++ b/.github/workflows/terraform-registry-manual-register.yml
@@ -98,10 +98,15 @@ jobs:
         run: |
           echo "🔍 Validating Terraform configuration..."
 
-          # Validate Terraform syntax and configuration
-          lace terraform validate --path "${{ inputs.module_path }}"
-
-          echo "✅ Terraform configuration is valid"
+          # Composite modules reference git sources that may not be tagged yet.
+          # Their structure is validated by lace module parse instead.
+          KIND=$(grep "^\s*kind:" "${{ inputs.module_path }}/module.yaml" | head -1 | awk '{print $2}')
+          if [ "$KIND" = "composite" ]; then
+            echo "ℹ️  Composite module — skipping terraform validate (lace module parse handles validation)"
+          else
+            lace terraform validate --path "${{ inputs.module_path }}"
+            echo "✅ Terraform configuration is valid"
+          fi
 
       - name: Terraform Security Scan (Optional)
         run: |


### PR DESCRIPTION
Composite modules reference leaf modules via git refs that may not be tagged yet, causing terraform init to fail. Composite structure is already validated by lace module parse, so terraform validate is not needed for them.

Also extends pr-validate-modules to trigger on PRs targeting main (develop -> main) in addition to develop.