### PR TITLE
chore: Add CODEOWNERS for workflow protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @lace-cloud/platform-team


### PR DESCRIPTION
## Summary

- Require `@lace-cloud/platform-team` approval for any `.github/` changes
- Missed from PR #19 merge (committed after approval)