### PR TITLE
fix: Add setup-terraform to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,10 @@ jobs:
           [ -f "$MODULE/module.yaml" ] || { echo "::error::module.yaml missing"; exit 1; }
           [ -f "$MODULE/main.tf" ]     || { echo "::error::main.tf missing"; exit 1; }
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.6.6"
+
       - name: Install Lace CLI
         run: |
           wget -q https://releases.lace.cloud/lace-cli-linux-amd64 -O lace


### PR DESCRIPTION
## Summary

- Add `hashicorp/setup-terraform@v3` step to `publish.yml`
- `lace terraform-registry register` runs `terraform validate` internally, which requires terraform on PATH
- Fixes publish failure on PR #20 merge