### PR TITLE
fix: Remove path filter from validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,6 @@ name: Validate Modules
 on:
   pull_request:
     branches: [develop, main]
-    paths: ['modules/**']
 
 concurrency:
   group: validate-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Removes `paths: ['modules/**']` filter from `validate.yml` so the workflow always triggers on PRs
- The `detect-changed-modules` job already handles the no-changes case gracefully, so this is safe
- Fixes checks showing as perpetually "pending" on PRs that don't touch module files

## Test plan
- [ ] PR with no module changes — workflow runs, summary reports "No module changes detected"
- [ ] PR with module changes — validates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)