### PR TITLE
chore: Extract gate into dedicated workflow

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,18 @@
+name: Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  source-branch:
+    name: Source Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop as source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::PRs to main must come from develop. Got: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "Source branch is develop — allowed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@ name: Validate Modules
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
 
 concurrency:
   group: validate-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- **New `gate.yml`** — standalone workflow for PRs to main, ensures only `develop` can merge
- **Updated `validate.yml`** — removed `main` from PR branch trigger (gate.yml handles main now)
- **Updated `protect-main` ruleset** — required check changed from `Publish Modules / Gate` to `Gate / Source Branch`

No module changes — expect: detect → skip validate → summary only.

## Test plan
- [ ] This PR: validate.yml runs, detects no module changes, skips validate, runs summary
- [ ] PR to main from develop: gate.yml passes
- [ ] PR to main from other branch: gate.yml fails
- [ ] Push to main with module changes: publish.yml runs


🤖 Generated with [Claude Code](https://claude.com/claude-code)