### PR TITLE
refactor: parameterize workflows for public/private registry forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,30 +154,37 @@ jobs:
 
       - name: Authenticate
         env:
-          LACE_API_KEY: ${{ secrets.LACE_SERVICE_ACCOUNT_KEY }}
+          LACE_API_KEY: ${{ secrets.LACE_API_KEY }}
         run: |
-          [ -z "$LACE_API_KEY" ] && { echo "::error::LACE_SERVICE_ACCOUNT_KEY secret not set"; exit 1; }
+          [ -z "$LACE_API_KEY" ] && { echo "::error::LACE_API_KEY secret not set"; exit 1; }
           lace whoami
 
       - name: Register module
         env:
-          LACE_API_KEY: ${{ secrets.LACE_SERVICE_ACCOUNT_KEY }}
+          LACE_API_KEY: ${{ secrets.LACE_API_KEY }}
+          LACE_ORGANIZATION: ${{ vars.LACE_ORGANIZATION }}
         run: |
+          ORG_FLAG=""
+          [ -n "$LACE_ORGANIZATION" ] && ORG_FLAG="--organization $LACE_ORGANIZATION"
           lace terraform-registry register \
             --module-path "${{ matrix.module_path }}" \
             --commit-sha "${{ github.sha }}" \
             --ref "${{ github.ref }}" \
-            --actor "${{ github.actor }}"
+            --actor "${{ github.actor }}" \
+            $ORG_FLAG
 
       - name: Verify registration
         env:
-          LACE_API_KEY: ${{ secrets.LACE_SERVICE_ACCOUNT_KEY }}
+          LACE_API_KEY: ${{ secrets.LACE_API_KEY }}
+          LACE_ORGANIZATION: ${{ vars.LACE_ORGANIZATION }}
         run: |
           MODULE="${{ matrix.module_path }}"
           NAME=$(grep "^  name:" "$MODULE/module.yaml" | head -1 | sed 's/^[^:]*: *//' | tr -d '"')
           SYSTEM=$(grep "^  system:" "$MODULE/module.yaml" | head -1 | sed 's/^[^:]*: *//' | tr -d '"')
           echo "Verifying: $SYSTEM/$NAME"
-          lace terraform-registry get "$NAME" "$SYSTEM"
+          ORG_FLAG=""
+          [ -n "$LACE_ORGANIZATION" ] && ORG_FLAG="--organization $LACE_ORGANIZATION"
+          lace terraform-registry get "$NAME" "$SYSTEM" $ORG_FLAG
 
   summary:
     name: Summary

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,8 +119,9 @@ jobs:
           done
 
           vis=$(grep "^  registry_visibility:" "$YAML" | head -1 | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'")
-          if [ -n "$vis" ] && [ "$vis" != "public" ]; then
-            echo "::error::registry_visibility must be 'public' for the public registry (got '$vis')"
+          EXPECTED="${{ vars.REGISTRY_VISIBILITY || 'public' }}"
+          if [ -n "$vis" ] && [ "$vis" != "$EXPECTED" ]; then
+            echo "::error::registry_visibility must be '$EXPECTED' (got '$vis')"
             errors=$((errors + 1))
           fi
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,48 @@ module:
 
 7. Merge to `main` — the module is automatically registered in the Lace registry.
 
+## Using This Repo as a Private Module Registry
+
+Enterprise teams can fork this repository to run a private Terraform module registry under their Lace organization.
+
+### Setup
+
+1. **Fork** this repo into your GitHub organization.
+
+2. **Set repository variables** (Settings → Secrets and variables → Actions → Variables):
+
+   | Variable | Value |
+   |----------|-------|
+   | `LACE_ORGANIZATION` | Your Lace org slug (e.g., `acme-corp`) |
+   | `REGISTRY_VISIBILITY` | `private` |
+
+3. **Set repository secret** (Settings → Secrets and variables → Actions → Secrets):
+
+   | Secret | Value |
+   |--------|-------|
+   | `LACE_API_KEY` | Org-scoped API key (create via `lace api-key create --organization <slug>`) |
+
+4. **Configure branch protection** on `develop` and `main` with the same required status check names (`Summary`, `Gate / Source Branch`).
+
+5. **Update `module.yaml` files** — set `registry_visibility: private` in each module's metadata:
+
+   ```yaml
+   module:
+     id: aws/s3/bucket
+     name: bucket
+     system: aws
+     version: 1.0.0
+     registry_visibility: private
+   ```
+
+6. **Customize the `authorize` job** (optional) — the Authorize job in `publish.yml` checks membership in `@<org>/platform-team` using a GitHub App. If you don't use the Lace GitHub App, either:
+   - Remove the `authorize` job and the `needs: authorize` line from the `prepare` job
+   - Or replace it with your own authorization mechanism
+
+### How it works
+
+When variables are unset (the default for the public `lace-cloud/registry-tf`), workflows behave exactly as before: modules are published to the public registry with visibility `public`. When `LACE_ORGANIZATION` is set, the CLI passes `--organization <slug>` to registry commands, scoping all operations to that org's private registry.
+
 ## Troubleshooting
 
 ### `organization is required for private modules`

--- a/platform.md
+++ b/platform.md
@@ -21,7 +21,7 @@ Runs on PRs targeting `develop`.
 **Validate checks (in order):**
 
 1. Structure — `module.yaml` + `main.tf` exist
-2. Field validation — `id`, `name`, `system`, `version`, `registry_visibility` present; visibility must be `public`
+2. Field validation — `id`, `name`, `system`, `version`, `registry_visibility` present; visibility must match `REGISTRY_VISIBILITY` variable (defaults to `public`)
 3. Module ID uniqueness — scans all `module.yaml` files in repo
 4. Version bump — compares `version` field against base branch; skipped for new modules
 5. `terraform fmt -check -recursive`
@@ -57,7 +57,7 @@ No concurrency group (single lightweight job).
 |-----|---------|
 | Authorize | Runs only for `workflow_dispatch`. Generates GitHub App token (`LACE_ORG_CI_APP_ID` + `LACE_ORG_CI_PRIVATE_KEY`), checks actor's membership in `platform-team` via API. |
 | Prepare | Runs if Authorize succeeded or was skipped. For push: `git diff HEAD^ HEAD` to find changed modules. For dispatch: validates the provided `module_path` exists. |
-| Register | Matrix per module (`fail-fast: false`). Each: validate structure → `setup-terraform` → install Lace CLI → authenticate with `LACE_SERVICE_ACCOUNT_KEY` → `lace terraform-registry register` → verify via `lace terraform-registry get`. |
+| Register | Matrix per module (`fail-fast: false`). Each: validate structure → `setup-terraform` → install Lace CLI → authenticate with `LACE_API_KEY` → `lace terraform-registry register` (with optional `--organization` from `LACE_ORGANIZATION`) → verify via `lace terraform-registry get`. |
 | Summary | Reports registered modules and result. |
 
 **Concurrency:** `publish-${{ github.ref }}`, does **not** cancel in-progress (every merge must publish).
@@ -84,9 +84,16 @@ CODEOWNERS: `/.github/ @lace-cloud/platform-team`
 
 | Secret | Purpose | Used by |
 |--------|---------|---------|
-| `LACE_SERVICE_ACCOUNT_KEY` | Service account API key for registry publishing | `publish.yml` (Register job) |
+| `LACE_API_KEY` | API key for registry publishing (service account key for public, org-scoped key for private) | `publish.yml` (Register job) |
 | `LACE_ORG_CI_APP_ID` | GitHub App ID for org API access | `publish.yml` (Authorize job) |
 | `LACE_ORG_CI_PRIVATE_KEY` | GitHub App private key | `publish.yml` (Authorize job) |
+
+## Variables
+
+| Variable | Default | Purpose | Used by |
+|----------|---------|---------|---------|
+| `LACE_ORGANIZATION` | _(unset)_ | Organization slug for private registries. When set, passes `--organization` to CLI commands. | `publish.yml` (Register job) |
+| `REGISTRY_VISIBILITY` | `public` | Expected `registry_visibility` value in `module.yaml`. Set to `private` for private registries. | `validate.yml` (Validate job) |
 
 ### Service Account
 
@@ -94,12 +101,13 @@ CODEOWNERS: `/.github/ @lace-cloud/platform-team`
 - **API Key:** hashed in `api_key` table, metadata `{ type: "service_account", purpose: "public_registry_publishing" }`
 - **Key generation:** `lace-middleware/scripts/create-service-account-key.ts` — generates crypto locally, outputs wrangler D1 commands
 - Service accounts can publish public modules without `x-org-slug` header (enforced in `terraform-registry.ts`)
+- **Rename note:** The repo secret was renamed from `LACE_SERVICE_ACCOUNT_KEY` to `LACE_API_KEY` to support both service account keys (public) and org-scoped keys (private forks)
 
 ## Troubleshooting
 
 ### CI validation passes but publish fails
 
-The Register job requires `LACE_SERVICE_ACCOUNT_KEY`. Verify it's set in repository Settings → Secrets and variables → Actions.
+The Register job requires `LACE_API_KEY`. Verify it's set in repository Settings → Secrets and variables → Actions.
 
 ### Manual dispatch authorization failure
 


### PR DESCRIPTION
## Summary
- **Secret rename**: `LACE_SERVICE_ACCOUNT_KEY` → `LACE_API_KEY` (already rotated in repo settings)
- **publish.yml**: Conditional `--organization` flag on register and verify steps via `vars.LACE_ORGANIZATION`
- **validate.yml**: Parameterize visibility check with `vars.REGISTRY_VISIBILITY` (defaults to `public`)
- **README.md**: Add "Using This Repo as a Private Module Registry" setup guide
- **platform.md**: Update secrets table, add variables table (`LACE_ORGANIZATION`, `REGISTRY_VISIBILITY`)

Backward compatible — when variables are unset, behavior is identical to before.

## Test plan
- [x] YAML validates cleanly (`yaml.safe_load` on all 3 workflows)
- [ ] Trigger publish workflow on a test module to verify `LACE_API_KEY` auth works
- [ ] Verify validate workflow still enforces `registry_visibility: public` by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)