### PR TITLE
Fix: register job silently skipped on push events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,7 +126,7 @@ jobs:
     name: Register
     runs-on: ubuntu-latest
     needs: prepare
-    if: needs.prepare.outputs.modules_found == 'true'
+    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.modules_found == 'true'
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

The `register` job in `publish.yml` never runs on push-triggered workflows due to GitHub Actions transitive skip propagation:

1. `authorize` is skipped on push events (`if: github.event_name == 'workflow_dispatch'`)
2. `prepare` overrides the skip with `if: always() && ...` — runs fine
3. `register` depends on `prepare` but lacks `always()` — GitHub propagates the skip from `authorize`, so register is silently skipped

**Result:** No module is ever published on push to main. Prepare detects modules, Summary reports them, but Register never executes.

**Fix:** Add `always()` to register's condition to break the transitive skip, while still requiring prepare to succeed and modules to be found.

```yaml
# before
if: needs.prepare.outputs.modules_found == 'true'

# after  
if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.modules_found == 'true'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)