### PR TITLE
feat: add ECS FastAPI deployment modules

### DIFF
--- a/modules/aws/alb/listener/main.tf
+++ b/modules/aws/alb/listener/main.tf
@@ -1,0 +1,28 @@
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = var.load_balancer_arn
+  port              = var.port
+  protocol          = var.protocol
+  ssl_policy        = var.protocol == "HTTPS" ? var.ssl_policy : null
+  certificate_arn   = var.protocol == "HTTPS" ? var.certificate_arn : null
+
+  default_action {
+    type             = var.default_action_type
+    target_group_arn = var.default_action_type == "forward" ? var.default_action_target_group_arn : null
+
+    dynamic "fixed_response" {
+      for_each = var.default_action_type == "fixed-response" ? [1] : []
+      content {
+        content_type = var.fixed_response_content_type
+        message_body = var.fixed_response_message_body
+        status_code  = var.fixed_response_status_code
+      }
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/alb/listener/module.yaml
+++ b/modules/aws/alb/listener/module.yaml
@@ -1,0 +1,31 @@
+module:
+  id: aws/alb/listener
+  name: alb-listener
+  system: aws
+  version: 1.0.0
+  description: "AWS ALB listener with default action and optional SSL certificate"
+  categories:
+    - networking
+    - load-balancing
+    - alb
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "listener" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/listener?ref=v1.0.0"
+
+      load_balancer_arn = module.alb.arn
+      port              = 443
+      protocol          = "HTTPS"
+      ssl_policy        = "ELBSecurityPolicy-2016-08"
+      certificate_arn   = "arn:aws:acm:us-east-1:123456789012:certificate/abc-123"
+
+      default_action_type             = "forward"
+      default_action_target_group_arn = module.target_group.arn
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/alb/listener/outputs.tf
+++ b/modules/aws/alb/listener/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "The ID of the listener"
+  value       = aws_lb_listener.this.id
+}
+
+output "arn" {
+  description = "The ARN of the listener"
+  value       = aws_lb_listener.this.arn
+}

--- a/modules/aws/alb/listener/variables.tf
+++ b/modules/aws/alb/listener/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  description = "A name tag for the listener"
+  type        = string
+  default     = ""
+}
+
+variable "load_balancer_arn" {
+  description = "The ARN of the ALB to attach the listener to"
+  type        = string
+}
+
+variable "port" {
+  description = "The port on which the listener receives traffic"
+  type        = number
+}
+
+variable "protocol" {
+  description = "The protocol for the listener (HTTP or HTTPS)"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "ssl_policy" {
+  description = "The SSL policy for an HTTPS listener"
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+}
+
+variable "certificate_arn" {
+  description = "The ARN of the SSL certificate for an HTTPS listener"
+  type        = string
+  default     = null
+}
+
+variable "default_action_type" {
+  description = "The type of default action (forward, fixed-response, redirect)"
+  type        = string
+  default     = "forward"
+}
+
+variable "default_action_target_group_arn" {
+  description = "The ARN of the target group for a forward action"
+  type        = string
+  default     = null
+}
+
+variable "fixed_response_content_type" {
+  description = "The content type for a fixed-response action"
+  type        = string
+  default     = "text/plain"
+}
+
+variable "fixed_response_message_body" {
+  description = "The message body for a fixed-response action"
+  type        = string
+  default     = null
+}
+
+variable "fixed_response_status_code" {
+  description = "The HTTP status code for a fixed-response action"
+  type        = string
+  default     = "200"
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the listener"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/alb/load_balancer/main.tf
+++ b/modules/aws/alb/load_balancer/main.tf
@@ -1,0 +1,25 @@
+resource "aws_lb" "this" {
+  name               = var.name
+  internal           = var.internal
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+  subnets            = var.subnet_ids
+
+  enable_deletion_protection = var.enable_deletion_protection
+
+  dynamic "access_logs" {
+    for_each = var.access_logs_bucket != null ? [1] : []
+    content {
+      bucket  = var.access_logs_bucket
+      prefix  = var.access_logs_prefix
+      enabled = true
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/alb/load_balancer/module.yaml
+++ b/modules/aws/alb/load_balancer/module.yaml
@@ -1,0 +1,27 @@
+module:
+  id: aws/alb/load_balancer
+  name: alb-load-balancer
+  system: aws
+  version: 1.0.0
+  description: "AWS Application Load Balancer with subnets, security groups, and access logs"
+  categories:
+    - networking
+    - load-balancing
+    - alb
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "alb" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/load_balancer?ref=v1.0.0"
+
+      name               = "my-alb"
+      internal           = false
+      security_group_ids = ["sg-123456"]
+      subnet_ids         = ["subnet-abc123", "subnet-def456"]
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/alb/load_balancer/outputs.tf
+++ b/modules/aws/alb/load_balancer/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "The ID of the ALB"
+  value       = aws_lb.this.id
+}
+
+output "arn" {
+  description = "The ARN of the ALB"
+  value       = aws_lb.this.arn
+}
+
+output "dns_name" {
+  description = "The DNS name of the ALB"
+  value       = aws_lb.this.dns_name
+}
+
+output "zone_id" {
+  description = "The canonical hosted zone ID of the ALB"
+  value       = aws_lb.this.zone_id
+}

--- a/modules/aws/alb/load_balancer/variables.tf
+++ b/modules/aws/alb/load_balancer/variables.tf
@@ -1,0 +1,44 @@
+variable "name" {
+  description = "The name of the Application Load Balancer"
+  type        = string
+}
+
+variable "internal" {
+  description = "Whether the ALB is internal (true) or internet-facing (false)"
+  type        = bool
+  default     = false
+}
+
+variable "security_group_ids" {
+  description = "The security group IDs to assign to the ALB"
+  type        = list(string)
+}
+
+variable "subnet_ids" {
+  description = "The subnet IDs to attach the ALB to"
+  type        = list(string)
+}
+
+variable "enable_deletion_protection" {
+  description = "Whether to enable deletion protection on the ALB"
+  type        = bool
+  default     = false
+}
+
+variable "access_logs_bucket" {
+  description = "The S3 bucket name for ALB access logs"
+  type        = string
+  default     = null
+}
+
+variable "access_logs_prefix" {
+  description = "The S3 key prefix for ALB access logs"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the ALB"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/alb/target_group/main.tf
+++ b/modules/aws/alb/target_group/main.tf
@@ -1,0 +1,28 @@
+resource "aws_lb_target_group" "this" {
+  name        = var.name
+  port        = var.port
+  protocol    = var.protocol
+  vpc_id      = var.vpc_id
+  target_type = var.target_type
+
+  dynamic "health_check" {
+    for_each = var.health_check != null ? [var.health_check] : []
+    content {
+      path                = lookup(health_check.value, "path", null)
+      port                = lookup(health_check.value, "port", "traffic-port")
+      protocol            = lookup(health_check.value, "protocol", "HTTP")
+      healthy_threshold   = lookup(health_check.value, "healthy_threshold", 3)
+      unhealthy_threshold = lookup(health_check.value, "unhealthy_threshold", 3)
+      timeout             = lookup(health_check.value, "timeout", 5)
+      interval            = lookup(health_check.value, "interval", 30)
+      matcher             = lookup(health_check.value, "matcher", "200")
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/alb/target_group/module.yaml
+++ b/modules/aws/alb/target_group/module.yaml
@@ -1,0 +1,38 @@
+module:
+  id: aws/alb/target_group
+  name: alb-target-group
+  system: aws
+  version: 1.0.0
+  description: "AWS ALB target group with health check configuration for Fargate (IP target type)"
+  categories:
+    - networking
+    - load-balancing
+    - alb
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "target_group" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/target_group?ref=v1.0.0"
+
+      name        = "my-tg"
+      port        = 80
+      protocol    = "HTTP"
+      vpc_id      = "vpc-123456"
+      target_type = "ip"
+
+      health_check = {
+        path                = "/health"
+        port                = "traffic-port"
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        timeout             = 5
+        interval            = 30
+        matcher             = "200"
+      }
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/alb/target_group/outputs.tf
+++ b/modules/aws/alb/target_group/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "The ID of the target group"
+  value       = aws_lb_target_group.this.id
+}
+
+output "arn" {
+  description = "The ARN of the target group"
+  value       = aws_lb_target_group.this.arn
+}
+
+output "name" {
+  description = "The name of the target group"
+  value       = aws_lb_target_group.this.name
+}

--- a/modules/aws/alb/target_group/variables.tf
+++ b/modules/aws/alb/target_group/variables.tf
@@ -1,0 +1,38 @@
+variable "name" {
+  description = "The name of the target group"
+  type        = string
+}
+
+variable "port" {
+  description = "The port on which targets receive traffic"
+  type        = number
+}
+
+variable "protocol" {
+  description = "The protocol to use for routing traffic to the targets"
+  type        = string
+  default     = "HTTP"
+}
+
+variable "vpc_id" {
+  description = "The VPC ID in which to create the target group"
+  type        = string
+}
+
+variable "target_type" {
+  description = "The type of target (instance, ip, lambda, alb)"
+  type        = string
+  default     = "ip"
+}
+
+variable "health_check" {
+  description = "Health check configuration for the target group"
+  type        = map(any)
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the target group"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/cloudwatch/log_group/main.tf
+++ b/modules/aws/cloudwatch/log_group/main.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = var.name
+  retention_in_days = var.retention_in_days
+  kms_key_id        = var.kms_key_id
+  log_group_class   = var.log_group_class
+  skip_destroy      = var.skip_destroy
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/cloudwatch/log_group/module.yaml
+++ b/modules/aws/cloudwatch/log_group/module.yaml
@@ -1,0 +1,23 @@
+module:
+  id: aws/cloudwatch/log_group
+  name: cloudwatch-log-group
+  system: aws
+  version: 1.0.0
+  description: "AWS CloudWatch Log Group with configurable retention and encryption"
+  categories:
+    - monitoring
+    - logging
+    - cloudwatch
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "logs" {
+      source            = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cloudwatch/log_group?ref=v1.0.0"
+      name              = "/app/my-service"
+      retention_in_days = 30
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/cloudwatch/log_group/outputs.tf
+++ b/modules/aws/cloudwatch/log_group/outputs.tf
@@ -1,0 +1,9 @@
+output "log_group_name" {
+  description = "Name of the CloudWatch log group"
+  value       = aws_cloudwatch_log_group.this.name
+}
+
+output "log_group_arn" {
+  description = "ARN of the CloudWatch log group"
+  value       = aws_cloudwatch_log_group.this.arn
+}

--- a/modules/aws/cloudwatch/log_group/variables.tf
+++ b/modules/aws/cloudwatch/log_group/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Name of the CloudWatch log group"
+  type        = string
+}
+
+variable "retention_in_days" {
+  description = "Number of days to retain log events (0 = never expire)"
+  type        = number
+  default     = 14
+}
+
+variable "kms_key_id" {
+  description = "KMS key ARN for log group encryption"
+  type        = string
+  default     = null
+}
+
+variable "log_group_class" {
+  description = "Log group class (STANDARD or INFREQUENT_ACCESS)"
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "skip_destroy" {
+  description = "Whether to skip destruction of the log group on delete"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/cloudwatch/metric_alarm/main.tf
+++ b/modules/aws/cloudwatch/metric_alarm/main.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_metric_alarm" "this" {
+  alarm_name          = var.alarm_name
+  alarm_description   = var.alarm_description
+  comparison_operator = var.comparison_operator
+  evaluation_periods  = var.evaluation_periods
+  metric_name         = var.metric_name
+  namespace           = var.namespace
+  period              = var.period
+  statistic           = var.statistic
+  threshold           = var.threshold
+  treat_missing_data  = var.treat_missing_data
+  datapoints_to_alarm = var.datapoints_to_alarm
+  dimensions          = var.dimensions
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.ok_actions
+  insufficient_data_actions = var.insufficient_data_actions
+
+  tags = merge(
+    {
+      Name = var.alarm_name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/cloudwatch/metric_alarm/main.tf
+++ b/modules/aws/cloudwatch/metric_alarm/main.tf
@@ -1,18 +1,18 @@
 resource "aws_cloudwatch_metric_alarm" "this" {
-  alarm_name          = var.alarm_name
-  alarm_description   = var.alarm_description
-  comparison_operator = var.comparison_operator
-  evaluation_periods  = var.evaluation_periods
-  metric_name         = var.metric_name
-  namespace           = var.namespace
-  period              = var.period
-  statistic           = var.statistic
-  threshold           = var.threshold
-  treat_missing_data  = var.treat_missing_data
-  datapoints_to_alarm = var.datapoints_to_alarm
-  dimensions          = var.dimensions
-  alarm_actions       = var.alarm_actions
-  ok_actions          = var.ok_actions
+  alarm_name                = var.alarm_name
+  alarm_description         = var.alarm_description
+  comparison_operator       = var.comparison_operator
+  evaluation_periods        = var.evaluation_periods
+  metric_name               = var.metric_name
+  namespace                 = var.namespace
+  period                    = var.period
+  statistic                 = var.statistic
+  threshold                 = var.threshold
+  treat_missing_data        = var.treat_missing_data
+  datapoints_to_alarm       = var.datapoints_to_alarm
+  dimensions                = var.dimensions
+  alarm_actions             = var.alarm_actions
+  ok_actions                = var.ok_actions
   insufficient_data_actions = var.insufficient_data_actions
 
   tags = merge(

--- a/modules/aws/cloudwatch/metric_alarm/module.yaml
+++ b/modules/aws/cloudwatch/metric_alarm/module.yaml
@@ -1,0 +1,30 @@
+module:
+  id: aws/cloudwatch/metric_alarm
+  name: cloudwatch-metric-alarm
+  system: aws
+  version: 1.0.0
+  description: "AWS CloudWatch Metric Alarm for monitoring and alerting on AWS resource metrics"
+  categories:
+    - monitoring
+    - cloudwatch
+    - alerting
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "alarm" {
+      source              = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cloudwatch/metric_alarm?ref=v1.0.0"
+      alarm_name          = "high-cpu-alarm"
+      comparison_operator = "GreaterThanThreshold"
+      evaluation_periods  = 2
+      metric_name         = "CPUUtilization"
+      namespace           = "AWS/EC2"
+      period              = 300
+      statistic           = "Average"
+      threshold           = 80
+      alarm_actions       = ["arn:aws:sns:us-east-1:123456789:alerts"]
+      dimensions = {
+        InstanceId = "i-1234567890abcdef0"
+      }
+    }

--- a/modules/aws/cloudwatch/metric_alarm/outputs.tf
+++ b/modules/aws/cloudwatch/metric_alarm/outputs.tf
@@ -1,0 +1,14 @@
+output "alarm_arn" {
+  description = "ARN of the CloudWatch metric alarm"
+  value       = aws_cloudwatch_metric_alarm.this.arn
+}
+
+output "alarm_name" {
+  description = "Name of the CloudWatch metric alarm"
+  value       = aws_cloudwatch_metric_alarm.this.alarm_name
+}
+
+output "alarm_id" {
+  description = "ID of the CloudWatch metric alarm"
+  value       = aws_cloudwatch_metric_alarm.this.id
+}

--- a/modules/aws/cloudwatch/metric_alarm/variables.tf
+++ b/modules/aws/cloudwatch/metric_alarm/variables.tf
@@ -1,0 +1,87 @@
+variable "alarm_name" {
+  description = "Name of the alarm"
+  type        = string
+}
+
+variable "alarm_description" {
+  description = "Description of the alarm"
+  type        = string
+  default     = ""
+}
+
+variable "comparison_operator" {
+  description = "Comparison operator (GreaterThanThreshold, LessThanThreshold, etc.)"
+  type        = string
+}
+
+variable "evaluation_periods" {
+  description = "Number of periods to evaluate"
+  type        = number
+}
+
+variable "metric_name" {
+  description = "Name of the metric"
+  type        = string
+}
+
+variable "namespace" {
+  description = "CloudWatch namespace for the metric"
+  type        = string
+}
+
+variable "period" {
+  description = "Period in seconds over which the statistic is applied"
+  type        = number
+}
+
+variable "statistic" {
+  description = "Statistic to apply (Average, Sum, Minimum, Maximum, SampleCount)"
+  type        = string
+}
+
+variable "threshold" {
+  description = "Threshold value for the alarm"
+  type        = number
+}
+
+variable "treat_missing_data" {
+  description = "How to treat missing data (missing, ignore, breaching, notBreaching)"
+  type        = string
+  default     = "missing"
+}
+
+variable "datapoints_to_alarm" {
+  description = "Number of datapoints that must breach to trigger alarm"
+  type        = number
+  default     = null
+}
+
+variable "dimensions" {
+  description = "Dimensions for the metric"
+  type        = map(string)
+  default     = {}
+}
+
+variable "alarm_actions" {
+  description = "List of ARNs to notify when alarm transitions to ALARM"
+  type        = list(string)
+  default     = []
+}
+
+variable "ok_actions" {
+  description = "List of ARNs to notify when alarm transitions to OK"
+  type        = list(string)
+  default     = []
+}
+
+variable "insufficient_data_actions" {
+  description = "List of ARNs to notify when alarm transitions to INSUFFICIENT_DATA"
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/ec2/security_group/main.tf
+++ b/modules/aws/ec2/security_group/main.tf
@@ -1,0 +1,38 @@
+resource "aws_security_group" "this" {
+  name        = var.name
+  description = var.description
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      cidr_blocks     = lookup(ingress.value, "cidr_blocks", null)
+      security_groups = lookup(ingress.value, "security_groups", null)
+      self            = lookup(ingress.value, "self", null)
+      description     = lookup(ingress.value, "description", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+    content {
+      from_port       = egress.value.from_port
+      to_port         = egress.value.to_port
+      protocol        = egress.value.protocol
+      cidr_blocks     = lookup(egress.value, "cidr_blocks", null)
+      security_groups = lookup(egress.value, "security_groups", null)
+      self            = lookup(egress.value, "self", null)
+      description     = lookup(egress.value, "description", null)
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/ec2/security_group/module.yaml
+++ b/modules/aws/ec2/security_group/module.yaml
@@ -1,0 +1,33 @@
+module:
+  id: aws/ec2/security_group
+  name: ec2-security-group
+  system: aws
+  version: 1.0.0
+  description: "AWS EC2 Security Group with configurable ingress and egress rules"
+  categories:
+    - networking
+    - security
+    - ec2
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "sg" {
+      source      = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ec2/security_group?ref=v1.0.0"
+      name        = "web-server-sg"
+      description = "Security group for web servers"
+      vpc_id      = "vpc-123456"
+      ingress_rules = [
+        {
+          from_port   = 443
+          to_port     = 443
+          protocol    = "tcp"
+          cidr_blocks = ["0.0.0.0/0"]
+          description = "HTTPS"
+        }
+      ]
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/ec2/security_group/outputs.tf
+++ b/modules/aws/ec2/security_group/outputs.tf
@@ -1,0 +1,14 @@
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.this.id
+}
+
+output "security_group_arn" {
+  description = "ARN of the security group"
+  value       = aws_security_group.this.arn
+}
+
+output "security_group_name" {
+  description = "Name of the security group"
+  value       = aws_security_group.this.name
+}

--- a/modules/aws/ec2/security_group/variables.tf
+++ b/modules/aws/ec2/security_group/variables.tf
@@ -1,0 +1,57 @@
+variable "name" {
+  description = "Name of the security group"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the security group"
+  type        = string
+  default     = "Managed by Terraform"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the security group will be created"
+  type        = string
+}
+
+variable "ingress_rules" {
+  description = "List of ingress rules"
+  type = list(object({
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+    self            = optional(bool)
+    description     = optional(string)
+  }))
+  default = []
+}
+
+variable "egress_rules" {
+  description = "List of egress rules"
+  type = list(object({
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+    self            = optional(bool)
+    description     = optional(string)
+  }))
+  default = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow all outbound"
+    }
+  ]
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/ecr/repository/main.tf
+++ b/modules/aws/ecr/repository/main.tf
@@ -1,0 +1,48 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = var.image_tag_mutability
+  force_delete         = var.force_delete
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  dynamic "encryption_configuration" {
+    for_each = var.encryption_type != null ? [1] : []
+    content {
+      encryption_type = var.encryption_type
+      kms_key         = var.kms_key
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  count      = length(var.lifecycle_rules) > 0 ? 1 : 0
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      for i, rule in var.lifecycle_rules : {
+        rulePriority = i + 1
+        description  = lookup(rule, "description", "Lifecycle rule ${i + 1}")
+        selection = {
+          tagStatus     = rule.tag_status
+          tagPrefixList = lookup(rule, "tag_prefix_list", null)
+          countType     = rule.count_type
+          countNumber   = rule.count_number
+          countUnit     = lookup(rule, "count_unit", null)
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/modules/aws/ecr/repository/module.yaml
+++ b/modules/aws/ecr/repository/module.yaml
@@ -1,0 +1,21 @@
+module:
+  id: aws/ecr/repository
+  name: ecr-repository
+  system: aws
+  version: 1.0.0
+  description: "AWS ECR repository with configurable image scanning, encryption, and lifecycle policies"
+  categories:
+    - containers
+    - ecr
+    - storage
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "ecr" {
+      source               = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecr/repository?ref=v1.0.0"
+      name                 = "my-app"
+      image_tag_mutability = "IMMUTABLE"
+      scan_on_push         = true
+    }

--- a/modules/aws/ecr/repository/outputs.tf
+++ b/modules/aws/ecr/repository/outputs.tf
@@ -1,0 +1,19 @@
+output "repository_url" {
+  description = "URL of the ECR repository"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "ARN of the ECR repository"
+  value       = aws_ecr_repository.this.arn
+}
+
+output "repository_name" {
+  description = "Name of the ECR repository"
+  value       = aws_ecr_repository.this.name
+}
+
+output "registry_id" {
+  description = "Registry ID"
+  value       = aws_ecr_repository.this.registry_id
+}

--- a/modules/aws/ecr/repository/variables.tf
+++ b/modules/aws/ecr/repository/variables.tf
@@ -1,0 +1,53 @@
+variable "name" {
+  description = "Name of the ECR repository"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "Image tag mutability (MUTABLE or IMMUTABLE)"
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "Enable image scanning on push"
+  type        = bool
+  default     = true
+}
+
+variable "encryption_type" {
+  description = "Encryption type (AES256 or KMS)"
+  type        = string
+  default     = null
+}
+
+variable "kms_key" {
+  description = "KMS key ARN for KMS encryption"
+  type        = string
+  default     = null
+}
+
+variable "force_delete" {
+  description = "Delete repository even if it contains images"
+  type        = bool
+  default     = false
+}
+
+variable "lifecycle_rules" {
+  description = "List of lifecycle policy rules"
+  type = list(object({
+    description     = optional(string)
+    tag_status      = string
+    tag_prefix_list = optional(list(string))
+    count_type      = string
+    count_number    = number
+    count_unit      = optional(string)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/ecs/cluster/main.tf
+++ b/modules/aws/ecs/cluster/main.tf
@@ -1,0 +1,30 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights ? "enabled" : "disabled"
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name = aws_ecs_cluster.this.name
+
+  capacity_providers = var.capacity_providers
+
+  dynamic "default_capacity_provider_strategy" {
+    for_each = var.default_capacity_provider_strategy
+    content {
+      capacity_provider = default_capacity_provider_strategy.value.capacity_provider
+      weight            = lookup(default_capacity_provider_strategy.value, "weight", null)
+      base              = lookup(default_capacity_provider_strategy.value, "base", null)
+    }
+  }
+}

--- a/modules/aws/ecs/cluster/module.yaml
+++ b/modules/aws/ecs/cluster/module.yaml
@@ -1,0 +1,36 @@
+module:
+  id: aws/ecs/cluster
+  name: ecs-cluster
+  system: aws
+  version: 1.0.0
+  description: "AWS ECS cluster with Container Insights and capacity provider configuration"
+  categories:
+    - compute
+    - containers
+    - ecs
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "ecs_cluster" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/cluster?ref=v1.0.0"
+
+      name = "my-cluster"
+
+      container_insights = true
+
+      capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+      default_capacity_provider_strategy = [
+        {
+          capacity_provider = "FARGATE"
+          weight            = 1
+          base              = 1
+        }
+      ]
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/ecs/cluster/outputs.tf
+++ b/modules/aws/ecs/cluster/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "The ID of the ECS cluster"
+  value       = aws_ecs_cluster.this.id
+}
+
+output "arn" {
+  description = "The ARN of the ECS cluster"
+  value       = aws_ecs_cluster.this.arn
+}
+
+output "name" {
+  description = "The name of the ECS cluster"
+  value       = aws_ecs_cluster.this.name
+}

--- a/modules/aws/ecs/cluster/variables.tf
+++ b/modules/aws/ecs/cluster/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "The name of the ECS cluster"
+  type        = string
+}
+
+variable "container_insights" {
+  description = "Whether to enable Container Insights for the cluster"
+  type        = bool
+  default     = true
+}
+
+variable "capacity_providers" {
+  description = "List of capacity providers to associate with the cluster"
+  type        = list(string)
+  default     = ["FARGATE"]
+}
+
+variable "default_capacity_provider_strategy" {
+  description = "Default capacity provider strategy for the cluster"
+  type = list(object({
+    capacity_provider = string
+    weight            = optional(number)
+    base              = optional(number)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the cluster"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/ecs/service/main.tf
+++ b/modules/aws/ecs/service/main.tf
@@ -1,0 +1,29 @@
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_id
+  task_definition = var.task_definition
+  desired_count   = var.desired_count
+  launch_type     = var.launch_type
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = var.security_group_ids
+    assign_public_ip = var.assign_public_ip
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.target_group_arn != null ? [1] : []
+    content {
+      target_group_arn = var.target_group_arn
+      container_name   = var.container_name
+      container_port   = var.container_port
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/ecs/service/module.yaml
+++ b/modules/aws/ecs/service/module.yaml
@@ -1,0 +1,34 @@
+module:
+  id: aws/ecs/service
+  name: ecs-service
+  system: aws
+  version: 1.0.0
+  description: "AWS ECS Fargate service with load balancer integration and network configuration"
+  categories:
+    - compute
+    - containers
+    - ecs
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "ecs_service" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/service?ref=v1.0.0"
+
+      name            = "my-service"
+      cluster_id      = module.ecs_cluster.id
+      task_definition = module.task_definition.arn
+      desired_count   = 2
+
+      subnet_ids         = ["subnet-abc123", "subnet-def456"]
+      security_group_ids = ["sg-123456"]
+
+      target_group_arn = module.target_group.arn
+      container_name   = "app"
+      container_port   = 80
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/ecs/service/outputs.tf
+++ b/modules/aws/ecs/service/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "The ID of the ECS service"
+  value       = aws_ecs_service.this.id
+}
+
+output "name" {
+  description = "The name of the ECS service"
+  value       = aws_ecs_service.this.name
+}
+
+output "cluster" {
+  description = "The cluster ARN of the ECS service"
+  value       = aws_ecs_service.this.cluster
+}

--- a/modules/aws/ecs/service/variables.tf
+++ b/modules/aws/ecs/service/variables.tf
@@ -1,0 +1,67 @@
+variable "name" {
+  description = "The name of the ECS service"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "The ID of the ECS cluster to run the service in"
+  type        = string
+}
+
+variable "task_definition" {
+  description = "The ARN of the task definition to use"
+  type        = string
+}
+
+variable "desired_count" {
+  description = "The number of task instances to run"
+  type        = number
+  default     = 1
+}
+
+variable "launch_type" {
+  description = "The launch type for the service"
+  type        = string
+  default     = "FARGATE"
+}
+
+variable "subnet_ids" {
+  description = "The subnet IDs for the service network configuration"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "The security group IDs for the service network configuration"
+  type        = list(string)
+  default     = []
+}
+
+variable "assign_public_ip" {
+  description = "Whether to assign a public IP to the task ENI"
+  type        = bool
+  default     = false
+}
+
+variable "target_group_arn" {
+  description = "The ARN of the ALB target group for load balancer integration"
+  type        = string
+  default     = null
+}
+
+variable "container_name" {
+  description = "The name of the container to associate with the load balancer"
+  type        = string
+  default     = null
+}
+
+variable "container_port" {
+  description = "The port on the container to associate with the load balancer"
+  type        = number
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the service"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/ecs/task_definition/main.tf
+++ b/modules/aws/ecs/task_definition/main.tf
@@ -1,0 +1,17 @@
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.family
+  requires_compatibilities = var.requires_compatibilities
+  network_mode             = var.network_mode
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+  container_definitions    = var.container_definitions
+
+  tags = merge(
+    {
+      Name = var.family
+    },
+    var.tags
+  )
+}

--- a/modules/aws/ecs/task_definition/module.yaml
+++ b/modules/aws/ecs/task_definition/module.yaml
@@ -1,0 +1,42 @@
+module:
+  id: aws/ecs/task_definition
+  name: ecs-task-definition
+  system: aws
+  version: 1.0.0
+  description: "AWS ECS task definition for Fargate with container definitions, CPU/memory, and IAM roles"
+  categories:
+    - compute
+    - containers
+    - ecs
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "task_definition" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/task_definition?ref=v1.0.0"
+
+      family             = "my-app"
+      cpu                = 256
+      memory             = 512
+      execution_role_arn = "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+      task_role_arn      = "arn:aws:iam::123456789012:role/ecsTaskRole"
+
+      container_definitions = jsonencode([
+        {
+          name      = "app"
+          image     = "nginx:latest"
+          essential = true
+          portMappings = [
+            {
+              containerPort = 80
+              protocol      = "tcp"
+            }
+          ]
+        }
+      ])
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/ecs/task_definition/outputs.tf
+++ b/modules/aws/ecs/task_definition/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "The full ARN of the task definition"
+  value       = aws_ecs_task_definition.this.arn
+}
+
+output "revision" {
+  description = "The revision number of the task definition"
+  value       = aws_ecs_task_definition.this.revision
+}
+
+output "family" {
+  description = "The family of the task definition"
+  value       = aws_ecs_task_definition.this.family
+}

--- a/modules/aws/ecs/task_definition/variables.tf
+++ b/modules/aws/ecs/task_definition/variables.tf
@@ -1,0 +1,48 @@
+variable "family" {
+  description = "A unique name for the task definition family"
+  type        = string
+}
+
+variable "requires_compatibilities" {
+  description = "A set of launch types required by the task"
+  type        = list(string)
+  default     = ["FARGATE"]
+}
+
+variable "network_mode" {
+  description = "The network mode to use for the task"
+  type        = string
+  default     = "awsvpc"
+}
+
+variable "cpu" {
+  description = "The number of CPU units for the task (e.g. 256, 512, 1024)"
+  type        = number
+}
+
+variable "memory" {
+  description = "The amount of memory in MiB for the task (e.g. 512, 1024, 2048)"
+  type        = number
+}
+
+variable "execution_role_arn" {
+  description = "The ARN of the IAM role for ECS task execution (pulling images, logging)"
+  type        = string
+}
+
+variable "task_role_arn" {
+  description = "The ARN of the IAM role for the task containers to call AWS APIs"
+  type        = string
+  default     = null
+}
+
+variable "container_definitions" {
+  description = "A JSON-encoded string of container definitions"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the task definition"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- Add 10 Terraform modules needed to deploy a FastAPI server to AWS ECS
- Modules sourced from `archive/all-modules` branch, cleaned up (removed `versions.tf`)

## Modules
| Module | Purpose |
|--------|---------|
| `ecr/repository` | Container image registry |
| `ecs/cluster` | ECS cluster with Container Insights |
| `ecs/task_definition` | Fargate task definition |
| `ecs/service` | ECS service with load balancer integration |
| `alb/load_balancer` | Application Load Balancer |
| `alb/target_group` | ALB target group with health checks |
| `alb/listener` | ALB HTTP/HTTPS listener rules |
| `ec2/security_group` | Security group with ingress/egress rules |
| `cloudwatch/log_group` | CloudWatch log group for container logs |
| `cloudwatch/metric_alarm` | CloudWatch metric alarms for monitoring |

## Test plan
- [ ] All modules have valid `module.yaml` and `main.tf`
- [ ] `terraform validate` passes on each module
- [ ] CI auto-registers modules after merge to main