### PR TITLE
feat: add AWS modules from nl-query-tool infrastructure

### DIFF
--- a/modules/aws/acm/certificate/main.tf
+++ b/modules/aws/acm/certificate/main.tf
@@ -1,0 +1,16 @@
+resource "aws_acm_certificate" "this" {
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = var.validation_method
+
+  tags = merge(
+    {
+      Name = var.domain_name
+    },
+    var.tags
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/aws/acm/certificate/module.yaml
+++ b/modules/aws/acm/certificate/module.yaml
@@ -1,0 +1,25 @@
+module:
+  id: aws/acm/certificate
+  name: acm-certificate
+  system: aws
+  version: 1.0.0
+  description: "AWS ACM certificate with DNS or EMAIL validation"
+  categories:
+    - acm
+    - security
+    - networking
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "certificate" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/acm/certificate?ref=v1.0.0"
+
+      domain_name       = "my-app.example.com"
+      validation_method = "DNS"
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/acm/certificate/outputs.tf
+++ b/modules/aws/acm/certificate/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "The ARN of the ACM certificate"
+  value       = aws_acm_certificate.this.arn
+}
+
+output "domain_validation_options" {
+  description = "Set of domain validation objects used to complete DNS validation"
+  value       = aws_acm_certificate.this.domain_validation_options
+}
+
+output "status" {
+  description = "The status of the certificate"
+  value       = aws_acm_certificate.this.status
+}

--- a/modules/aws/acm/certificate/variables.tf
+++ b/modules/aws/acm/certificate/variables.tf
@@ -1,0 +1,22 @@
+variable "domain_name" {
+  description = "The domain name for which the certificate should be issued"
+  type        = string
+}
+
+variable "subject_alternative_names" {
+  description = "Additional domain names to include in the certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "validation_method" {
+  description = "The validation method to use (DNS or EMAIL)"
+  type        = string
+  default     = "DNS"
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the certificate"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/acm/certificate/versions.tf
+++ b/modules/aws/acm/certificate/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/cognito/user_pool/main.tf
+++ b/modules/aws/cognito/user_pool/main.tf
@@ -1,0 +1,37 @@
+resource "aws_cognito_user_pool" "this" {
+  name                     = var.name
+  username_attributes      = var.username_attributes
+  auto_verified_attributes = var.auto_verified_attributes
+
+  dynamic "password_policy" {
+    for_each = var.password_policy != null ? [var.password_policy] : []
+    content {
+      minimum_length                   = password_policy.value.minimum_length
+      require_lowercase                = password_policy.value.require_lowercase
+      require_uppercase                = password_policy.value.require_uppercase
+      require_numbers                  = password_policy.value.require_numbers
+      require_symbols                  = password_policy.value.require_symbols
+      temporary_password_validity_days = password_policy.value.temporary_password_validity_days
+    }
+  }
+
+  dynamic "account_recovery_setting" {
+    for_each = var.recovery_mechanisms != null ? [1] : []
+    content {
+      dynamic "recovery_mechanism" {
+        for_each = var.recovery_mechanisms
+        content {
+          name     = recovery_mechanism.value.name
+          priority = recovery_mechanism.value.priority
+        }
+      }
+    }
+  }
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/cognito/user_pool/module.yaml
+++ b/modules/aws/cognito/user_pool/module.yaml
@@ -1,0 +1,27 @@
+module:
+  id: aws/cognito/user_pool
+  name: cognito-user-pool
+  system: aws
+  version: 1.0.0
+  description: "AWS Cognito user pool with configurable password policy and email verification"
+  categories:
+    - cognito
+    - auth
+    - security
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "user_pool" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool?ref=v1.0.0"
+
+      name = "my-app-prod-users"
+
+      username_attributes      = ["email"]
+      auto_verified_attributes = ["email"]
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/cognito/user_pool/outputs.tf
+++ b/modules/aws/cognito/user_pool/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "The ID of the Cognito user pool"
+  value       = aws_cognito_user_pool.this.id
+}
+
+output "arn" {
+  description = "The ARN of the Cognito user pool"
+  value       = aws_cognito_user_pool.this.arn
+}
+
+output "endpoint" {
+  description = "The endpoint name of the user pool"
+  value       = aws_cognito_user_pool.this.endpoint
+}

--- a/modules/aws/cognito/user_pool/variables.tf
+++ b/modules/aws/cognito/user_pool/variables.tf
@@ -1,0 +1,49 @@
+variable "name" {
+  description = "The name of the Cognito user pool"
+  type        = string
+}
+
+variable "username_attributes" {
+  description = "Attributes supported as an alias for this user pool (e.g. email, phone_number)"
+  type        = list(string)
+  default     = ["email"]
+}
+
+variable "auto_verified_attributes" {
+  description = "Attributes to be auto-verified (e.g. email, phone_number)"
+  type        = list(string)
+  default     = ["email"]
+}
+
+variable "password_policy" {
+  description = "Password policy configuration for the user pool"
+  type = object({
+    minimum_length                   = optional(number, 8)
+    require_lowercase                = optional(bool, true)
+    require_uppercase                = optional(bool, true)
+    require_numbers                  = optional(bool, true)
+    require_symbols                  = optional(bool, false)
+    temporary_password_validity_days = optional(number, 7)
+  })
+  default = {}
+}
+
+variable "recovery_mechanisms" {
+  description = "List of account recovery mechanisms. Each object must have name and priority."
+  type = list(object({
+    name     = string
+    priority = number
+  }))
+  default = [
+    {
+      name     = "verified_email"
+      priority = 1
+    }
+  ]
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the user pool"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/cognito/user_pool/versions.tf
+++ b/modules/aws/cognito/user_pool/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/cognito/user_pool_client/main.tf
+++ b/modules/aws/cognito/user_pool_client/main.tf
@@ -1,0 +1,27 @@
+resource "aws_cognito_user_pool_client" "this" {
+  name         = var.name
+  user_pool_id = var.user_pool_id
+
+  generate_secret = var.generate_secret
+
+  allowed_oauth_flows                  = var.allowed_oauth_flows
+  allowed_oauth_scopes                 = var.allowed_oauth_scopes
+  allowed_oauth_flows_user_pool_client = var.allowed_oauth_flows_user_pool_client
+  supported_identity_providers         = var.supported_identity_providers
+
+  callback_urls = length(var.callback_urls) > 0 ? var.callback_urls : null
+  logout_urls   = length(var.logout_urls) > 0 ? var.logout_urls : null
+
+  access_token_validity  = var.access_token_validity
+  id_token_validity      = var.id_token_validity
+  refresh_token_validity = var.refresh_token_validity
+
+  dynamic "token_validity_units" {
+    for_each = var.token_validity_units != null ? [var.token_validity_units] : []
+    content {
+      access_token  = lookup(token_validity_units.value, "access_token", "hours")
+      id_token      = lookup(token_validity_units.value, "id_token", "hours")
+      refresh_token = lookup(token_validity_units.value, "refresh_token", "days")
+    }
+  }
+}

--- a/modules/aws/cognito/user_pool_client/module.yaml
+++ b/modules/aws/cognito/user_pool_client/module.yaml
@@ -1,0 +1,28 @@
+module:
+  id: aws/cognito/user_pool_client
+  name: cognito-user-pool-client
+  system: aws
+  version: 1.0.0
+  description: "AWS Cognito user pool app client with configurable OAuth flows, scopes, and token validity"
+  categories:
+    - cognito
+    - auth
+    - security
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "user_pool_client" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool_client?ref=v1.0.0"
+
+      name         = "my-app-prod-alb-client"
+      user_pool_id = module.user_pool.id
+
+      generate_secret      = true
+      allowed_oauth_flows  = ["code"]
+      allowed_oauth_scopes = ["openid", "email", "profile"]
+
+      callback_urls = ["https://my-app.example.com/oauth2/idpresponse"]
+      logout_urls   = ["https://my-app.example.com"]
+    }

--- a/modules/aws/cognito/user_pool_client/outputs.tf
+++ b/modules/aws/cognito/user_pool_client/outputs.tf
@@ -1,0 +1,10 @@
+output "id" {
+  description = "The ID of the Cognito user pool client"
+  value       = aws_cognito_user_pool_client.this.id
+}
+
+output "client_secret" {
+  description = "The client secret (only set if generate_secret is true)"
+  value       = aws_cognito_user_pool_client.this.client_secret
+  sensitive   = true
+}

--- a/modules/aws/cognito/user_pool_client/variables.tf
+++ b/modules/aws/cognito/user_pool_client/variables.tf
@@ -1,0 +1,79 @@
+variable "name" {
+  description = "The name of the Cognito user pool client"
+  type        = string
+}
+
+variable "user_pool_id" {
+  description = "The ID of the Cognito user pool"
+  type        = string
+}
+
+variable "generate_secret" {
+  description = "Whether to generate a client secret (required for ALB OIDC integration)"
+  type        = bool
+  default     = false
+}
+
+variable "allowed_oauth_flows" {
+  description = "List of allowed OAuth flows (e.g. code, implicit, client_credentials)"
+  type        = list(string)
+  default     = ["code"]
+}
+
+variable "allowed_oauth_scopes" {
+  description = "List of allowed OAuth scopes (e.g. openid, email, profile)"
+  type        = list(string)
+  default     = ["openid", "email", "profile"]
+}
+
+variable "allowed_oauth_flows_user_pool_client" {
+  description = "Whether the client is allowed to use OAuth flows"
+  type        = bool
+  default     = true
+}
+
+variable "supported_identity_providers" {
+  description = "List of identity providers supported by this client"
+  type        = list(string)
+  default     = ["COGNITO"]
+}
+
+variable "callback_urls" {
+  description = "List of allowed callback URLs after authentication"
+  type        = list(string)
+  default     = []
+}
+
+variable "logout_urls" {
+  description = "List of allowed logout URLs"
+  type        = list(string)
+  default     = []
+}
+
+variable "access_token_validity" {
+  description = "Time limit for access tokens"
+  type        = number
+  default     = 1
+}
+
+variable "id_token_validity" {
+  description = "Time limit for ID tokens"
+  type        = number
+  default     = 1
+}
+
+variable "refresh_token_validity" {
+  description = "Time limit for refresh tokens"
+  type        = number
+  default     = 30
+}
+
+variable "token_validity_units" {
+  description = "Token validity unit configuration. Keys: access_token, id_token, refresh_token. Valid values: seconds, minutes, hours, days"
+  type        = map(string)
+  default = {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+}

--- a/modules/aws/cognito/user_pool_client/versions.tf
+++ b/modules/aws/cognito/user_pool_client/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/cognito/user_pool_domain/main.tf
+++ b/modules/aws/cognito/user_pool_domain/main.tf
@@ -1,0 +1,4 @@
+resource "aws_cognito_user_pool_domain" "this" {
+  domain       = var.domain
+  user_pool_id = var.user_pool_id
+}

--- a/modules/aws/cognito/user_pool_domain/module.yaml
+++ b/modules/aws/cognito/user_pool_domain/module.yaml
@@ -1,0 +1,21 @@
+module:
+  id: aws/cognito/user_pool_domain
+  name: cognito-user-pool-domain
+  system: aws
+  version: 1.0.0
+  description: "AWS Cognito hosted UI domain for a user pool"
+  categories:
+    - cognito
+    - auth
+    - security
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "user_pool_domain" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool_domain?ref=v1.0.0"
+
+      domain       = "my-app-prod"
+      user_pool_id = module.user_pool.id
+    }

--- a/modules/aws/cognito/user_pool_domain/outputs.tf
+++ b/modules/aws/cognito/user_pool_domain/outputs.tf
@@ -1,0 +1,9 @@
+output "domain" {
+  description = "The Cognito hosted UI domain"
+  value       = aws_cognito_user_pool_domain.this.domain
+}
+
+output "cloudfront_distribution_arn" {
+  description = "The ARN of the CloudFront distribution backing the hosted UI"
+  value       = aws_cognito_user_pool_domain.this.cloudfront_distribution_arn
+}

--- a/modules/aws/cognito/user_pool_domain/variables.tf
+++ b/modules/aws/cognito/user_pool_domain/variables.tf
@@ -1,0 +1,9 @@
+variable "domain" {
+  description = "The Cognito hosted UI domain prefix (must be unique across AWS)"
+  type        = string
+}
+
+variable "user_pool_id" {
+  description = "The ID of the Cognito user pool to associate the domain with"
+  type        = string
+}

--- a/modules/aws/cognito/user_pool_domain/versions.tf
+++ b/modules/aws/cognito/user_pool_domain/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/rds/instance/main.tf
+++ b/modules/aws/rds/instance/main.tf
@@ -1,0 +1,38 @@
+resource "aws_db_instance" "this" {
+  identifier     = var.name
+  engine         = var.engine
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = var.storage_type
+  storage_encrypted     = var.storage_encrypted
+
+  db_name  = var.db_name
+  username = var.username
+  password = var.password
+
+  db_subnet_group_name   = var.db_subnet_group_name
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  backup_retention_period      = var.backup_retention_period
+  backup_window                = var.backup_window
+  maintenance_window           = var.maintenance_window
+  deletion_protection          = var.deletion_protection
+  skip_final_snapshot          = var.skip_final_snapshot
+  final_snapshot_identifier    = var.skip_final_snapshot ? null : "${var.name}-final-snapshot"
+  performance_insights_enabled = var.performance_insights_enabled
+  multi_az                     = var.multi_az
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}

--- a/modules/aws/rds/instance/module.yaml
+++ b/modules/aws/rds/instance/module.yaml
@@ -1,0 +1,39 @@
+module:
+  id: aws/rds/instance
+  name: rds-instance
+  system: aws
+  version: 1.0.0
+  description: "AWS RDS database instance with subnet group, storage autoscaling, and configurable backup and maintenance settings"
+  categories:
+    - database
+    - rds
+    - storage
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "rds" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/rds/instance?ref=v1.0.0"
+
+      name           = "my-app-prod-postgres"
+      engine         = "postgres"
+      engine_version = "15"
+      instance_class = "db.t3.small"
+
+      db_name  = "myapp"
+      username = "appuser"
+      password = var.db_password
+
+      db_subnet_group_name   = module.rds_subnet_group.name
+      vpc_security_group_ids = [module.rds_sg.id]
+
+      allocated_storage     = 20
+      max_allocated_storage = 100
+      multi_az              = false
+      deletion_protection   = true
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/rds/instance/outputs.tf
+++ b/modules/aws/rds/instance/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "The RDS instance identifier"
+  value       = aws_db_instance.this.id
+}
+
+output "arn" {
+  description = "The ARN of the RDS instance"
+  value       = aws_db_instance.this.arn
+}
+
+output "address" {
+  description = "The hostname of the RDS instance"
+  value       = aws_db_instance.this.address
+}
+
+output "endpoint" {
+  description = "The connection endpoint (host:port)"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "port" {
+  description = "The port the database is listening on"
+  value       = aws_db_instance.this.port
+}

--- a/modules/aws/rds/instance/variables.tf
+++ b/modules/aws/rds/instance/variables.tf
@@ -1,0 +1,121 @@
+variable "name" {
+  description = "The identifier for the RDS instance and subnet group"
+  type        = string
+}
+
+variable "engine" {
+  description = "The database engine (e.g. postgres, mysql)"
+  type        = string
+  default     = "postgres"
+}
+
+variable "engine_version" {
+  description = "The version of the database engine"
+  type        = string
+  default     = "15"
+}
+
+variable "instance_class" {
+  description = "The instance type of the RDS instance"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "allocated_storage" {
+  description = "The initial allocated storage in GiB"
+  type        = number
+  default     = 20
+}
+
+variable "max_allocated_storage" {
+  description = "The upper limit for storage autoscaling in GiB. Set to 0 to disable autoscaling"
+  type        = number
+  default     = 100
+}
+
+variable "storage_type" {
+  description = "The storage type (gp2, gp3, io1)"
+  type        = string
+  default     = "gp3"
+}
+
+variable "storage_encrypted" {
+  description = "Whether the DB storage is encrypted"
+  type        = bool
+  default     = true
+}
+
+variable "db_name" {
+  description = "The name of the database to create"
+  type        = string
+}
+
+variable "username" {
+  description = "The master username for the database"
+  type        = string
+}
+
+variable "password" {
+  description = "The master password for the database"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_subnet_group_name" {
+  description = "The name of the DB subnet group to associate with the instance"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of VPC security group IDs to associate with the instance"
+  type        = list(string)
+  default     = []
+}
+
+variable "backup_retention_period" {
+  description = "The number of days to retain backups"
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "The daily time range during which automated backups are created (UTC)"
+  type        = string
+  default     = "03:00-04:00"
+}
+
+variable "maintenance_window" {
+  description = "The window for maintenance operations"
+  type        = string
+  default     = "Mon:04:00-Mon:05:00"
+}
+
+variable "deletion_protection" {
+  description = "Whether deletion protection is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "skip_final_snapshot" {
+  description = "Whether to skip the final snapshot on deletion"
+  type        = bool
+  default     = false
+}
+
+variable "performance_insights_enabled" {
+  description = "Whether to enable Performance Insights"
+  type        = bool
+  default     = true
+}
+
+variable "multi_az" {
+  description = "Whether to enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "A map of tags to assign to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/rds/instance/versions.tf
+++ b/modules/aws/rds/instance/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/rds/subnet_group/main.tf
+++ b/modules/aws/rds/subnet_group/main.tf
@@ -1,0 +1,12 @@
+resource "aws_db_subnet_group" "this" {
+  name        = var.name
+  subnet_ids  = var.subnet_ids
+  description = var.description
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}

--- a/modules/aws/rds/subnet_group/module.yaml
+++ b/modules/aws/rds/subnet_group/module.yaml
@@ -1,0 +1,25 @@
+module:
+  id: aws/rds/subnet_group
+  name: rds-subnet-group
+  system: aws
+  version: 1.0.0
+  description: "AWS RDS DB subnet group for placing RDS instances within a VPC"
+  categories:
+    - database
+    - rds
+    - networking
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "rds_subnet_group" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/rds/subnet_group?ref=v1.0.0"
+
+      name       = "my-app-prod-rds"
+      subnet_ids = module.vpc.private_subnet_ids
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/rds/subnet_group/outputs.tf
+++ b/modules/aws/rds/subnet_group/outputs.tf
@@ -1,0 +1,14 @@
+output "name" {
+  description = "The name of the DB subnet group"
+  value       = aws_db_subnet_group.this.name
+}
+
+output "id" {
+  description = "The ID of the DB subnet group"
+  value       = aws_db_subnet_group.this.id
+}
+
+output "arn" {
+  description = "The ARN of the DB subnet group"
+  value       = aws_db_subnet_group.this.arn
+}

--- a/modules/aws/rds/subnet_group/variables.tf
+++ b/modules/aws/rds/subnet_group/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  description = "The name of the DB subnet group"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "A list of VPC subnet IDs to include in the subnet group"
+  type        = list(string)
+}
+
+variable "description" {
+  description = "A description for the DB subnet group"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the subnet group"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/rds/subnet_group/versions.tf
+++ b/modules/aws/rds/subnet_group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/route53/record/main.tf
+++ b/modules/aws/route53/record/main.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_record" "this" {
+  zone_id         = var.zone_id
+  name            = var.name
+  type            = var.type
+  ttl             = var.alias != null ? null : var.ttl
+  records         = var.alias != null ? null : var.records
+  allow_overwrite = var.allow_overwrite
+
+  dynamic "alias" {
+    for_each = var.alias != null ? [1] : []
+    content {
+      name                   = var.alias.name
+      zone_id                = var.alias.zone_id
+      evaluate_target_health = var.alias.evaluate_target_health
+    }
+  }
+}

--- a/modules/aws/route53/record/module.yaml
+++ b/modules/aws/route53/record/module.yaml
@@ -1,0 +1,28 @@
+module:
+  id: aws/route53/record
+  name: route53-record
+  system: aws
+  version: 1.0.0
+  description: "AWS Route53 DNS record supporting both standard and alias record types"
+  categories:
+    - route53
+    - dns
+    - networking
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "dns_record" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/route53/record?ref=v1.0.0"
+
+      zone_id = data.aws_route53_zone.main.zone_id
+      name    = "my-app.example.com"
+      type    = "A"
+
+      alias = {
+        name                   = module.alb.dns_name
+        zone_id                = module.alb.zone_id
+        evaluate_target_health = true
+      }
+    }

--- a/modules/aws/route53/record/outputs.tf
+++ b/modules/aws/route53/record/outputs.tf
@@ -1,0 +1,9 @@
+output "fqdn" {
+  description = "The FQDN built using the zone domain and name"
+  value       = aws_route53_record.this.fqdn
+}
+
+output "name" {
+  description = "The name of the DNS record"
+  value       = aws_route53_record.this.name
+}

--- a/modules/aws/route53/record/variables.tf
+++ b/modules/aws/route53/record/variables.tf
@@ -1,0 +1,44 @@
+variable "zone_id" {
+  description = "The ID of the hosted zone to contain this record"
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the DNS record"
+  type        = string
+}
+
+variable "type" {
+  description = "The record type (A, AAAA, CNAME, MX, TXT, etc.)"
+  type        = string
+}
+
+variable "ttl" {
+  description = "The TTL of the record in seconds. Not used for alias records"
+  type        = number
+  nullable    = true
+  default     = 60
+}
+
+variable "records" {
+  description = "A list of record values. Not used for alias records"
+  type        = list(string)
+  nullable    = true
+  default     = null
+}
+
+variable "allow_overwrite" {
+  description = "Whether to allow overwriting an existing record"
+  type        = bool
+  default     = false
+}
+
+variable "alias" {
+  description = "Alias block for routing to AWS resources. Set to null for non-alias records"
+  type = object({
+    name                   = string
+    zone_id                = string
+    evaluate_target_health = bool
+  })
+  default = null
+}

--- a/modules/aws/route53/record/versions.tf
+++ b/modules/aws/route53/record/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/s3/bucket/main.tf
+++ b/modules/aws/s3/bucket/main.tf
@@ -1,0 +1,93 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket
+
+  tags = merge(
+    {
+      Name = var.bucket
+    },
+    var.tags
+  )
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.kms_key_id != null ? "aws:kms" : "AES256"
+      kms_master_key_id = var.kms_key_id
+    }
+    bucket_key_enabled = var.kms_key_id != null ? true : false
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count  = var.lifecycle_rules != null ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  dynamic "rule" {
+    for_each = var.lifecycle_rules
+    content {
+      id     = rule.value.id
+      status = lookup(rule.value, "enabled", true) ? "Enabled" : "Disabled"
+
+      dynamic "filter" {
+        for_each = lookup(rule.value, "prefix", null) != null ? [1] : []
+        content {
+          prefix = rule.value.prefix
+        }
+      }
+
+      dynamic "filter" {
+        for_each = lookup(rule.value, "prefix", null) == null ? [1] : []
+        content {}
+      }
+
+      dynamic "expiration" {
+        for_each = lookup(rule.value, "expiration_days", null) != null ? [1] : []
+        content {
+          days = rule.value.expiration_days
+        }
+      }
+
+      dynamic "noncurrent_version_expiration" {
+        for_each = lookup(rule.value, "noncurrent_version_expiration_days", null) != null ? [1] : []
+        content {
+          noncurrent_days = rule.value.noncurrent_version_expiration_days
+        }
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "this" {
+  count  = length(var.cors_rules) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  dynamic "cors_rule" {
+    for_each = var.cors_rules
+    content {
+      allowed_headers = lookup(cors_rule.value, "allowed_headers", ["*"])
+      allowed_methods = cors_rule.value.allowed_methods
+      allowed_origins = cors_rule.value.allowed_origins
+      expose_headers  = lookup(cors_rule.value, "expose_headers", [])
+      max_age_seconds = lookup(cors_rule.value, "max_age_seconds", 3600)
+    }
+  }
+}

--- a/modules/aws/s3/bucket/module.yaml
+++ b/modules/aws/s3/bucket/module.yaml
@@ -1,0 +1,40 @@
+module:
+  id: aws/s3/bucket
+  name: s3-bucket
+  system: aws
+  version: 1.0.0
+  description: "AWS S3 bucket with versioning, KMS encryption, public access block, lifecycle rules, and optional CORS configuration"
+  categories:
+    - storage
+    - s3
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "uploads_bucket" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/s3/bucket?ref=v1.0.0"
+
+      bucket             = "my-app-prod-uploads-123456789"
+      versioning_enabled = true
+
+      lifecycle_rules = [
+        {
+          id              = "expire-raw-uploads"
+          expiration_days = 90
+          noncurrent_version_expiration_days = 30
+        }
+      ]
+
+      cors_rules = [
+        {
+          allowed_methods = ["GET", "PUT", "POST"]
+          allowed_origins = ["https://my-app.example.com"]
+          expose_headers  = ["ETag"]
+        }
+      ]
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/s3/bucket/outputs.tf
+++ b/modules/aws/s3/bucket/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "The name of the bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "arn" {
+  description = "The ARN of the bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_domain_name" {
+  description = "The bucket domain name"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "The bucket region-specific domain name"
+  value       = aws_s3_bucket.this.bucket_regional_domain_name
+}

--- a/modules/aws/s3/bucket/variables.tf
+++ b/modules/aws/s3/bucket/variables.tf
@@ -1,0 +1,46 @@
+variable "bucket" {
+  description = "The name of the S3 bucket"
+  type        = string
+}
+
+variable "versioning_enabled" {
+  description = "Whether to enable versioning on the bucket"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_id" {
+  description = "The KMS key ID for server-side encryption. If null, uses AES256"
+  type        = string
+  default     = null
+}
+
+variable "lifecycle_rules" {
+  description = "List of lifecycle rules to apply to the bucket"
+  type = list(object({
+    id                                 = string
+    enabled                            = optional(bool, true)
+    prefix                             = optional(string)
+    expiration_days                    = optional(number)
+    noncurrent_version_expiration_days = optional(number)
+  }))
+  default = null
+}
+
+variable "cors_rules" {
+  description = "List of CORS rules to apply to the bucket"
+  type = list(object({
+    allowed_headers = optional(list(string), ["*"])
+    allowed_methods = list(string)
+    allowed_origins = list(string)
+    expose_headers  = optional(list(string), [])
+    max_age_seconds = optional(number, 3600)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/s3/bucket/versions.tf
+++ b/modules/aws/s3/bucket/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/secretsmanager/secret/main.tf
+++ b/modules/aws/secretsmanager/secret/main.tf
@@ -1,0 +1,24 @@
+resource "aws_secretsmanager_secret" "this" {
+  name        = var.name
+  description = var.description
+  kms_key_id  = var.kms_key_id
+
+  recovery_window_in_days = var.recovery_window_in_days
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  count         = var.secret_string != null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = var.secret_string
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/modules/aws/secretsmanager/secret/module.yaml
+++ b/modules/aws/secretsmanager/secret/module.yaml
@@ -1,0 +1,25 @@
+module:
+  id: aws/secretsmanager/secret
+  name: secretsmanager-secret
+  system: aws
+  version: 1.0.0
+  description: "AWS Secrets Manager secret with optional initial value and KMS encryption"
+  categories:
+    - security
+    - secrets
+    - secretsmanager
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "api_key_secret" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/secretsmanager/secret?ref=v1.0.0"
+
+      name        = "my-app/prod/api-key"
+      description = "API key for third-party service"
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/secretsmanager/secret/outputs.tf
+++ b/modules/aws/secretsmanager/secret/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "The ID of the secret"
+  value       = aws_secretsmanager_secret.this.id
+}
+
+output "arn" {
+  description = "The ARN of the secret"
+  value       = aws_secretsmanager_secret.this.arn
+}
+
+output "name" {
+  description = "The name of the secret"
+  value       = aws_secretsmanager_secret.this.name
+}

--- a/modules/aws/secretsmanager/secret/variables.tf
+++ b/modules/aws/secretsmanager/secret/variables.tf
@@ -1,0 +1,35 @@
+variable "name" {
+  description = "The name of the secret"
+  type        = string
+}
+
+variable "description" {
+  description = "A description of the secret"
+  type        = string
+  default     = ""
+}
+
+variable "kms_key_id" {
+  description = "The KMS key ID to use for encryption. If null, uses the default Secrets Manager key"
+  type        = string
+  default     = null
+}
+
+variable "recovery_window_in_days" {
+  description = "Number of days that Secrets Manager waits before deleting the secret. Set to 0 to delete immediately"
+  type        = number
+  default     = 30
+}
+
+variable "secret_string" {
+  description = "The initial secret value as a string. If null, no version is created (value must be set manually)"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the secret"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/secretsmanager/secret/versions.tf
+++ b/modules/aws/secretsmanager/secret/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -1,0 +1,129 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support   = var.enable_dns_support
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_subnet" "public" {
+  count             = var.public_subnet_count
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.cidr_block, var.subnet_newbits, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  map_public_ip_on_launch = false
+
+  tags = merge(
+    {
+      Name = "${var.name}-public-${count.index + 1}"
+    },
+    var.tags
+  )
+}
+
+resource "aws_subnet" "private" {
+  count             = var.private_subnet_count
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.cidr_block, var.subnet_newbits, count.index + var.private_subnet_offset)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge(
+    {
+      Name = "${var.name}-private-${count.index + 1}"
+    },
+    var.tags
+  )
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    {
+      Name = "${var.name}-igw"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(
+    {
+      Name = "${var.name}-public-rt"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route_table_association" "public" {
+  count          = var.public_subnet_count
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+
+  tags = merge(
+    {
+      Name = "${var.name}-nat-eip"
+    },
+    var.tags
+  )
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(
+    {
+      Name = "${var.name}-nat"
+    },
+    var.tags
+  )
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "private" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this[0].id
+  }
+
+  tags = merge(
+    {
+      Name = "${var.name}-private-rt"
+    },
+    var.tags
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  count          = var.enable_nat_gateway ? var.private_subnet_count : 0
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[0].id
+}

--- a/modules/aws/vpc/module.yaml
+++ b/modules/aws/vpc/module.yaml
@@ -1,0 +1,28 @@
+module:
+  id: aws/vpc
+  name: vpc
+  system: aws
+  version: 1.0.0
+  description: "AWS VPC with public and private subnets, Internet Gateway, NAT Gateway, and route tables"
+  categories:
+    - networking
+    - vpc
+  authors:
+    - name: "Lace Team"
+      email: "team@lace.cloud"
+  registry_visibility: public
+  example: |
+    module "vpc" {
+      source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/vpc?ref=v1.0.0"
+
+      name       = "my-app-prod"
+      cidr_block = "10.0.0.0/16"
+
+      public_subnet_count  = 2
+      private_subnet_count = 2
+      enable_nat_gateway   = true
+
+      tags = {
+        Environment = "production"
+      }
+    }

--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway (null if enable_nat_gateway is false)"
+  value       = var.enable_nat_gateway ? aws_nat_gateway.this[0].id : null
+}

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -1,0 +1,58 @@
+variable "name" {
+  description = "Name prefix applied to all resources"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "The CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "enable_dns_hostnames" {
+  description = "Whether to enable DNS hostnames in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Whether to enable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "public_subnet_count" {
+  description = "Number of public subnets to create"
+  type        = number
+  default     = 2
+}
+
+variable "private_subnet_count" {
+  description = "Number of private subnets to create"
+  type        = number
+  default     = 2
+}
+
+variable "subnet_newbits" {
+  description = "Number of bits to extend the VPC CIDR for each subnet"
+  type        = number
+  default     = 8
+}
+
+variable "private_subnet_offset" {
+  description = "Index offset for private subnet CIDR calculation to avoid overlap with public subnets"
+  type        = number
+  default     = 10
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create a NAT gateway and private route table"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to assign to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Add 10 Terraform modules extracted from nl-query-tool production infrastructure:
- vpc
- rds/instance, rds/subnet_group
- s3/bucket
- secretsmanager/secret
- cognito/user_pool, cognito/user_pool_domain, cognito/user_pool_client
- acm/certificate
- route53/record