### PR TITLE
chore: remove unused registry_visibility from module.yaml

### DIFF
--- a/modules/aws/acm/certificate/module.yaml
+++ b/modules/aws/acm/certificate/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "certificate" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/acm/certificate?ref=v1.0.0"

--- a/modules/aws/alb/listener/module.yaml
+++ b/modules/aws/alb/listener/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "listener" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/listener?ref=v1.0.0"

--- a/modules/aws/alb/listener_rule/module.yaml
+++ b/modules/aws/alb/listener_rule/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "listener_rule" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/listener_rule?ref=v1.0.0"

--- a/modules/aws/alb/load_balancer/module.yaml
+++ b/modules/aws/alb/load_balancer/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "alb" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/load_balancer?ref=v1.0.0"

--- a/modules/aws/alb/target_group/module.yaml
+++ b/modules/aws/alb/target_group/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "target_group" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/alb/target_group?ref=v1.0.0"

--- a/modules/aws/cloudwatch/log_group/module.yaml
+++ b/modules/aws/cloudwatch/log_group/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "logs" {
       source            = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cloudwatch/log_group?ref=v1.0.0"

--- a/modules/aws/cloudwatch/metric_alarm/module.yaml
+++ b/modules/aws/cloudwatch/metric_alarm/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "alarm" {
       source              = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cloudwatch/metric_alarm?ref=v1.0.0"

--- a/modules/aws/cognito/user_pool/module.yaml
+++ b/modules/aws/cognito/user_pool/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "user_pool" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool?ref=v1.0.0"

--- a/modules/aws/cognito/user_pool_client/module.yaml
+++ b/modules/aws/cognito/user_pool_client/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "user_pool_client" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool_client?ref=v1.0.0"

--- a/modules/aws/cognito/user_pool_domain/module.yaml
+++ b/modules/aws/cognito/user_pool_domain/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "user_pool_domain" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/cognito/user_pool_domain?ref=v1.0.0"

--- a/modules/aws/ec2/security_group/module.yaml
+++ b/modules/aws/ec2/security_group/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "sg" {
       source      = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ec2/security_group?ref=v1.0.0"

--- a/modules/aws/ecr/repository/module.yaml
+++ b/modules/aws/ecr/repository/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "ecr" {
       source               = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecr/repository?ref=v1.0.0"

--- a/modules/aws/ecs/cluster/module.yaml
+++ b/modules/aws/ecs/cluster/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "ecs_cluster" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/cluster?ref=v1.0.0"

--- a/modules/aws/ecs/service/module.yaml
+++ b/modules/aws/ecs/service/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "ecs_service" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/service?ref=v1.0.0"

--- a/modules/aws/ecs/task_definition/module.yaml
+++ b/modules/aws/ecs/task_definition/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "task_definition" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/ecs/task_definition?ref=v1.0.0"

--- a/modules/aws/iam/policy/module.yaml
+++ b/modules/aws/iam/policy/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "policy" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/iam/policy?ref=v1.0.0"

--- a/modules/aws/iam/policy_attachment/module.yaml
+++ b/modules/aws/iam/policy_attachment/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "attachment" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/iam/policy_attachment?ref=v1.0.0"

--- a/modules/aws/rds/instance/module.yaml
+++ b/modules/aws/rds/instance/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "rds" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/rds/instance?ref=v1.0.0"

--- a/modules/aws/rds/subnet_group/module.yaml
+++ b/modules/aws/rds/subnet_group/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "rds_subnet_group" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/rds/subnet_group?ref=v1.0.0"

--- a/modules/aws/route53/record/module.yaml
+++ b/modules/aws/route53/record/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "dns_record" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/route53/record?ref=v1.0.0"

--- a/modules/aws/s3/bucket/module.yaml
+++ b/modules/aws/s3/bucket/module.yaml
@@ -10,7 +10,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "uploads_bucket" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/s3/bucket?ref=v1.0.0"

--- a/modules/aws/secretsmanager/secret/module.yaml
+++ b/modules/aws/secretsmanager/secret/module.yaml
@@ -11,7 +11,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "api_key_secret" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/secretsmanager/secret?ref=v1.0.0"

--- a/modules/aws/vpc/module.yaml
+++ b/modules/aws/vpc/module.yaml
@@ -10,7 +10,6 @@ module:
   authors:
     - name: "Lace Team"
       email: "team@lace.cloud"
-  registry_visibility: public
   example: |
     module "vpc" {
       source = "git::https://github.com/lace-cloud/registry-tf.git//modules/aws/vpc?ref=v1.0.0"


### PR DESCRIPTION
## Summary

Removes the `registry_visibility` field from all 23 `module.yaml` files.

## Why

This field is not used anywhere in the system:

- **CLI** (`ModuleYaml` struct in `terraform_registry.go`) does not parse it -- it's ignored during registration
- **Middleware** (`terraform-registry-service.ts`) has no `registry_visibility` column on `terraform_module` -- the org-level column was added in migration 0003 and **removed** in migration 0010
- **Visibility** is determined solely by `orgId` -- modules owned by `LACE_PUBLIC_REGISTRY_ORG_ID` (`org_lace_cloud_001`) are public; everything else is org-scoped/private
- **Validate workflow** already doesn't check it (only validates `id`, `name`, `system`, `version`)

Keeping the field creates confusion (ref: #103 question from @rohandudam).

## Changes

- Removed `registry_visibility: public` line from all 23 module.yaml files
- No version bumps needed since this is metadata cleanup, not a module behavior change

Ref: #103